### PR TITLE
prevented a character(0) pathname from being insta-read

### DIFF
--- a/inst/app/bits/load_video.R
+++ b/inst/app/bits/load_video.R
@@ -2,7 +2,7 @@ shinyFileChoose(input, "the_video", session = session,
                 roots = c(wd = normalizePath(ifelse(.Platform$OS.type == "unix", "~/", "~/.."))))
 
 observe({
-  if (!is.null(input$the_video)) {
+  if (!is.null(input$the_video)) {  #what the heck is this? input is *ALWAYS* not NULL....
     isolate({
       path <- parseFilePaths(roots = c(wd = normalizePath(ifelse(.Platform$OS.type == "unix",
                                                                  "~/", "~/.."))), input$the_video)
@@ -11,9 +11,10 @@ observe({
         the_dat <<- suppressMessages(read_csv(paste0(as.character(path$datapath), ".csv")))
         updateSliderInput(session, "the_frame_slider", value = max(the_dat$frame, na.rm = TRUE))
       }
-
-      react$the_video <- video(as.character(path$datapath))
-      react$update_plot <- react$update_plot + 1
+      if (length(as.character(path$datapath)) != 0L) {
+         react$the_video <- video(as.character(path$datapath))
+         react$update_plot <- react$update_plot + 1
+        }
     })
   }
 })


### PR DESCRIPTION
I added a simple if-statement that wraps the reaction part. when trying to load movie files. (This is what my problem was, not anything being a newer version, etc.)
It seemed to be instantly reading a `character(0)` value for `as.character(path$datapath)` because that line is run even before a file can be actually selected. 
Also, I'm not sure why this is all wrapped in an if-statement for `!is.null(input$the_video)` when input literally loads at a value of `0` which is not NULL... Who cares though! Finally works now.